### PR TITLE
Added a way to manually reset the database for a process

### DIFF
--- a/daemon/extendedprocess.php.inc
+++ b/daemon/extendedprocess.php.inc
@@ -404,6 +404,14 @@ class ExtendedSiteFusionProcess extends SiteFusionProcess
 		if( self::$Options['debug'] )
 			socket_close( self::$DebugSocket );
 	}
+
+	static public function RemoveDatabaseLink(){
+		self::$Database = NULL;
+	}
+	
+	static public function CreateDatabaseLink(){
+		self::GetDatabaseConnection();
+	}
 }
 
 


### PR DESCRIPTION
These two methods give the developer a way to normally reset the database for the entire process. This would be required on forking.
